### PR TITLE
refactor: use new camunda spring-boot-starter dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,7 +44,7 @@
 
 		<dependency>
 			<groupId>io.camunda</groupId>
-			<artifactId>spring-boot-starter-camunda-sdk</artifactId>
+			<artifactId>camunda-spring-boot-starter</artifactId>
 			<version>8.8.0</version>
 		</dependency>
 


### PR DESCRIPTION
While still available as alias,`spring-boot-starter-camunda-sdk` was superseded by `camunda-spring-boot-starter`. See https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-spring-boot-starter.