### PR TITLE
fix(config): convert configuration to YAML so Spring Boot loads settings

### DIFF
--- a/java/src/main/resources/application.yml
+++ b/java/src/main/resources/application.yml
@@ -1,9 +1,10 @@
-spring.application.name=Process Order
+spring.application.name: Process Order
 camunda:
     client:
         mode: self-managed
         grpc-address: http://127.0.0.1:26500
         rest-address: http://127.0.0.1:8080
 
-logging.level.io.camunda.client.impl.CamundaCallCredentials=ERROR
+logging.level:
+    io.camunda.client.impl.CamundaCallCredentials: ERROR
 


### PR DESCRIPTION
**Summary** 
Convert malformed `application.properties` into a valid YAML file at `src/main/resources/application.yml` so Spring Boot loads configuration values.

**Problem:**
- The previous file mixed `=` and `:` syntax and was ignored by Spring Boot, so settings like `camunda.client.rest-address` had no effect.

**Change:**
- Replaced the malformed properties file with a valid `application.yml`. No code changes.

**How to verify:**
1. Update the config values in application.yml
2. Run the app: `./mvnw spring-boot:run`
3. Confirm  config values (e.g.`spring.application.name` and `camunda.client.*`) are applied at startup (check logs or behavior).
4. Run tests: `./mvnw test`

