### PR TITLE
feat(java): apply convention-over-configuration for Spring Boot job workers

### DIFF
--- a/2-order-process-with-service-workers/bpmn/order-process.bpmn
+++ b/2-order-process-with-service-workers/bpmn/order-process.bpmn
@@ -13,21 +13,21 @@
     <bpmn:sequenceFlow id="Flow_1asktip" sourceRef="Activity_08pg6im" targetRef="Event_0f9sbko" />
     <bpmn:serviceTask id="Activity_0tw2fu0" name="Check inventory">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="check-inventory" />
+        <zeebe:taskDefinition type="checkInventory" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1mpm94e</bpmn:incoming>
       <bpmn:outgoing>Flow_0udsae3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_1ppsbgi" name="Charge payment method">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="charge-payment" />
+        <zeebe:taskDefinition type="chargePayment" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0udsae3</bpmn:incoming>
       <bpmn:outgoing>Flow_0g2bnlp</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_08pg6im" name="Ship items">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="ship-items" />
+        <zeebe:taskDefinition type="shipItems" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0g2bnlp</bpmn:incoming>
       <bpmn:outgoing>Flow_1asktip</bpmn:outgoing>

--- a/2-order-process-with-service-workers/java/pom.xml
+++ b/2-order-process-with-service-workers/java/pom.xml
@@ -68,6 +68,15 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgs>
+						<arg>-parameters</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 				<executions>
 					<execution>

--- a/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/ChargePaymentWorker.java
+++ b/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/ChargePaymentWorker.java
@@ -1,7 +1,6 @@
 package io.camunda.demo.process_order;
 
 import io.camunda.client.annotation.JobWorker;
-import io.camunda.client.api.response.ActivatedJob;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,11 +8,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ChargePaymentWorker {
- private final static Logger LOG = LoggerFactory.getLogger(ChargePaymentWorker.class);
-    @JobWorker(type = "charge-payment")
-    public void processPayment(final ActivatedJob job) {
-        LOG.info("Processing charge-payment job: {}", job.getKey());
-        LOG.info("charge-payment job completed: {}", job.getKey());
-        return;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChargePaymentWorker.class);
+
+    @JobWorker
+    public void chargePayment() {
+        LOG.info("Charging payment");
     }
 }

--- a/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/CheckInventoryWorker.java
+++ b/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/CheckInventoryWorker.java
@@ -4,26 +4,20 @@ import java.util.Map;
 
 import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.annotation.Variable;
-import io.camunda.client.api.response.ActivatedJob;
 import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-
 @Component
 public class CheckInventoryWorker {
-    private final static Logger LOG = LoggerFactory.getLogger(CheckInventoryWorker.class);
-    @JobWorker(type = "check-inventory")
-    public Map<String, String> checkInventory(final ActivatedJob job, @Variable(name = "item") @Nullable String itemOrdered) {
-        String item;
-        if (itemOrdered == null || itemOrdered.isEmpty()) {
-            item = "default-item";
-        } else {
-            item = itemOrdered;
-        }
-        LOG.info("Checking inventory for item: {}", job.getKey());
-        LOG.info("check-inventory completed ");
-        return Map.of("item", item + " allocated");
+
+    private static final Logger LOG = LoggerFactory.getLogger(CheckInventoryWorker.class);
+
+    @JobWorker
+    public Map<String, String> checkInventory(@Variable @Nullable String item) {
+        String allocated = (item == null || item.isEmpty()) ? "default-item" : item;
+        LOG.info("Checking inventory for item: {}", allocated);
+        return Map.of("item", allocated + " allocated");
     }
 }

--- a/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/ShipItemsWorker.java
+++ b/2-order-process-with-service-workers/java/src/main/java/io/camunda/demo/process_order/ShipItemsWorker.java
@@ -1,20 +1,19 @@
 package io.camunda.demo.process_order;
+
 import io.camunda.client.annotation.JobWorker;
-import io.camunda.client.api.response.ActivatedJob;
-
-import java.util.Map;
-
+import io.camunda.client.annotation.Variable;
+import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ShipItemsWorker {
- private final static Logger LOG = LoggerFactory.getLogger(ShipItemsWorker.class);
-    @JobWorker(type = "ship-items")
-    public Map<String, String> shipItems(final ActivatedJob job) {
-        LOG.info("Processing ship-items job: {}", job.getKey());
-        LOG.info("ship-items job completed: {}", job.getKey());
-        return Map.of();
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShipItemsWorker.class);
+
+    @JobWorker
+    public void shipItems(@Variable @Nullable String item) {
+        LOG.info("Shipping item: {}", item);
     }
 }

--- a/2-order-process-with-service-workers/java/src/main/resources/application.properties
+++ b/2-order-process-with-service-workers/java/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.application.name=Process Order
-camunda:
-    client:
-        mode: self-managed
-        grpc-address: http://127.0.0.1:26500
-        rest-address: http://127.0.0.1:8080
-
-logging.level.io.camunda.client.impl.CamundaCallCredentials=ERROR
-

--- a/2-order-process-with-service-workers/java/src/main/resources/application.yaml
+++ b/2-order-process-with-service-workers/java/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: Process Order
+
+camunda:
+  client:
+    mode: self-managed
+    grpc-address: http://127.0.0.1:26500
+    rest-address: http://127.0.0.1:8080
+
+logging:
+  level:
+    io.camunda.client.impl.CamundaCallCredentials: ERROR

--- a/2-order-process-with-service-workers/java/src/test/java/io/camunda/demo/process_order/ProcessOrderApplicationTests.java
+++ b/2-order-process-with-service-workers/java/src/test/java/io/camunda/demo/process_order/ProcessOrderApplicationTests.java
@@ -33,9 +33,9 @@ public class ProcessOrderApplicationTests {
                 .latestVersion()
                 .send()
                 .join();
-        processTestContext.mockJobWorker("check-inventory").thenComplete();
-        processTestContext.mockJobWorker("charge-payment").thenComplete();
-        processTestContext.mockJobWorker("ship-items").thenComplete();
+        processTestContext.mockJobWorker("checkInventory").thenComplete();
+        processTestContext.mockJobWorker("chargePayment").thenComplete();
+        processTestContext.mockJobWorker("shipItems").thenComplete();
         // then
         CamundaAssert.assertThat(processInstance).isCompleted();
     }

--- a/2-order-process-with-service-workers/java/src/test/resources/order-process.bpmn
+++ b/2-order-process-with-service-workers/java/src/test/resources/order-process.bpmn
@@ -13,21 +13,21 @@
     <bpmn:sequenceFlow id="Flow_1asktip" sourceRef="Activity_08pg6im" targetRef="Event_0f9sbko" />
     <bpmn:serviceTask id="Activity_0tw2fu0" name="Check inventory">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="check-inventory" />
+        <zeebe:taskDefinition type="checkInventory" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1mpm94e</bpmn:incoming>
       <bpmn:outgoing>Flow_0udsae3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_1ppsbgi" name="Charge payment method">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="charge-payment" />
+        <zeebe:taskDefinition type="chargePayment" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0udsae3</bpmn:incoming>
       <bpmn:outgoing>Flow_0g2bnlp</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_08pg6im" name="Ship items">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="ship-items" />
+        <zeebe:taskDefinition type="shipItems" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0g2bnlp</bpmn:incoming>
       <bpmn:outgoing>Flow_1asktip</bpmn:outgoing>


### PR DESCRIPTION
## Summary

Applies the convention-over-configuration approach documented in [camunda/camunda-docs#9265](https://github.com/camunda/camunda-docs/pull/9265) to the Java getting-started example.

### What changed

**BPMN task types** — renamed from kebab-case to camelCase so Java method names can serve as the job type without repetition:
- `check-inventory` → `checkInventory`
- `charge-payment` → `chargePayment`
- `ship-items` → `shipItems`

**Workers** — removed all `type = "..."` attributes; the method name is now the job type:
- `ChargePaymentWorker`: dropped `type = "charge-payment"` and the unused `ActivatedJob` parameter (was only used to log `job.getKey()`); renamed `processPayment` → `chargePayment` to match the process type
- `CheckInventoryWorker`: dropped `type = "check-inventory"` and `ActivatedJob`; simplified from `@Variable(name = "item") String itemOrdered` to `@Variable String item` (parameter name used directly with `-parameters` flag)
- `ShipItemsWorker`: dropped `type = "ship-items"` and the unused `ActivatedJob`; added `@Variable @Nullable String item` to fetch only the needed variable

**`pom.xml`** — added `-parameters` Maven compiler flag so `@Variable` uses parameter names automatically without a `name` attribute.

**`application.properties` → `application.yaml`** — the original file mixed Java properties syntax (`key=value`) with YAML block syntax (`camunda:` / `logging:`). The YAML block was never parsed by a `.properties` reader, so the Camunda client mode and addresses were silently ignored. Renamed to `.yaml` and rewrote as consistent YAML.

**Test** — updated `mockJobWorker` calls to use the new camelCase type names.

### Before / after (CheckInventoryWorker)

**Before:**
```java
@JobWorker(type = "check-inventory")
public Map<String, String> checkInventory(final ActivatedJob job,
    @Variable(name = "item") @Nullable String itemOrdered) {
  String item = (itemOrdered == null || itemOrdered.isEmpty()) ? "default-item" : itemOrdered;
  LOG.info("Checking inventory for item: {}", job.getKey());
  return Map.of("item", item + " allocated");
}
```

**After:**
```java
@JobWorker
public Map<String, String> checkInventory(@Variable @Nullable String item) {
  String allocated = (item == null || item.isEmpty()) ? "default-item" : item;
  LOG.info("Checking inventory for item: {}", allocated);
  return Map.of("item", allocated + " allocated");
}
```

## Test plan

- [ ] `mvn test` passes in `2-order-process-with-service-workers/java/`
- [ ] Application connects to a local Camunda cluster (`c8ctl cluster start`) and completes a process instance end-to-end
