### PR TITLE
Make browser order-process inputs/workers editable

### DIFF
--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -23,6 +23,8 @@ Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
   walks the diagram task-by-task; a failed job turns its task red (an incident).
 - Editable input parameters (JSON), plus editable worker code for each BPMN
   `zeebe:taskDefinition type`. Edit and press **Run** to watch the process react.
+- The default `check-inventory` worker treats `quantity >= 10` as out of stock,
+  so you can quickly test alternate paths by changing only input JSON.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 
@@ -43,6 +45,8 @@ variables to merge (or throws to fail the job):
 ```js
 async (job) => {
   const item = job.variables.item ?? "default-item";
+  const quantity = Number(job.variables.quantity ?? 1);
+  if (quantity >= 10) return { item, inStock: false };
   return { item: item + " allocated", inStock: true };
 };
 ```

--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -21,9 +21,8 @@ Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
 - The `order-process.bpmn` model (a copy of `../bpmn/order-process.bpmn`)
   rendered live with [bpmn-js](https://github.com/bpmn-io/bpmn-js). A green token
   walks the diagram task-by-task; a failed job turns its task red (an incident).
-- Three editable workers — `check-inventory`, `charge-payment`, `ship-items` —
-  one per BPMN `zeebe:taskDefinition type`. Edit the code, press **Run**, and
-  watch the process react.
+- Editable input parameters (JSON), plus editable worker code for each BPMN
+  `zeebe:taskDefinition type`. Edit and press **Run** to watch the process react.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 

--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -23,9 +23,6 @@ Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
   walks the diagram task-by-task; a failed job turns its task red (an incident).
 - Editable input parameters (JSON), plus editable worker code for each BPMN
   `zeebe:taskDefinition type`. Edit and press **Run** to watch the process react.
-- The default `check-inventory` worker treats `quantity >= 10` as out of stock,
-  and `charge-payment` / `ship-items` then fail with an incident, so you can
-  quickly test alternate paths by changing only input JSON.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 
@@ -46,17 +43,13 @@ variables to merge (or throws to fail the job):
 ```js
 async (job) => {
   const item = job.variables.item ?? "default-item";
-  const quantity = Number(job.variables.quantity ?? 1);
-  if (quantity >= 10) return { item, inStock: false };
   return { item: item + " allocated", inStock: true };
 };
 ```
 
 Everything else — the token advancing, gateways, the variables merging — is the
 real engine, running on WebAssembly. Try making `ship-items` `throw new
-Error("no stock")` and re-run to see an incident appear on the diagram. With the
-default handlers, setting `quantity` to `10` or higher already triggers that
-incident path.
+Error("no stock")` and re-run to see an incident appear on the diagram.
 
 ## Scripts
 

--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -15,6 +15,8 @@ npm run dev
 ```
 
 Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
+Then change input values and service worker code, and run again to compare the
+result.
 
 ## What you get
 
@@ -22,7 +24,8 @@ Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
   rendered live with [bpmn-js](https://github.com/bpmn-io/bpmn-js). A green token
   walks the diagram task-by-task; a failed job turns its task red (an incident).
 - Editable input parameters (JSON), plus editable worker code for each BPMN
-  `zeebe:taskDefinition type`. Edit and press **Run** to watch the process react.
+  `zeebe:taskDefinition type`. Change both freely and press **Run** repeatedly
+  to see how the process behavior changes.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 

--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -24,7 +24,8 @@ Open the URL it prints (default <http://localhost:5173>) and press **▶ Run**.
 - Editable input parameters (JSON), plus editable worker code for each BPMN
   `zeebe:taskDefinition type`. Edit and press **Run** to watch the process react.
 - The default `check-inventory` worker treats `quantity >= 10` as out of stock,
-  so you can quickly test alternate paths by changing only input JSON.
+  and `charge-payment` / `ship-items` then fail with an incident, so you can
+  quickly test alternate paths by changing only input JSON.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 
@@ -53,7 +54,9 @@ async (job) => {
 
 Everything else — the token advancing, gateways, the variables merging — is the
 real engine, running on WebAssembly. Try making `ship-items` `throw new
-Error("no stock")` and re-run to see an incident appear on the diagram.
+Error("no stock")` and re-run to see an incident appear on the diagram. With the
+default handlers, setting `quantity` to `10` or higher already triggers that
+incident path.
 
 ## Scripts
 

--- a/2-order-process-with-service-workers/browser/README.md
+++ b/2-order-process-with-service-workers/browser/README.md
@@ -26,6 +26,8 @@ result.
 - Editable input parameters (JSON), plus editable worker code for each BPMN
   `zeebe:taskDefinition type`. Change both freely and press **Run** repeatedly
   to see how the process behavior changes.
+- The BPMN model itself is read-only in this browser demo; this example focuses
+  on tweaking input values and worker behavior.
 - A live **Variables** panel (the instance payload) and an **Activity** log of
   what each worker did.
 

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -241,11 +241,7 @@ export function App() {
             <code>nodejs/</code> example — but there is no Camunda 8 cluster here.
             The real nanobpm engine executes the process in your browser. Edit a
             worker's JavaScript on the right, hit <strong>Run</strong>, and watch
-            the token move and the variables change. By default,{" "}
-            <code>check-inventory</code> marks orders with{" "}
-            <code>quantity &gt;= 10</code> as out of stock, and{" "}
-            <code>charge-payment</code>/<code>ship-items</code> raise an incident
-            when that happens.
+            the token move and the variables change.
           </p>
           <div className="controls">
             <Button onClick={run} disabled={phase !== "ready" || running}>
@@ -260,7 +256,7 @@ export function App() {
               className="seed seed-button"
               onClick={() => setShowInputEditor((v) => !v)}
               disabled={running}
-              title="Click to edit input parameters (quantity >= 10 becomes out of stock and raises incident)"
+              title="Click to edit input parameters"
             >
               <span className="seed-edit-icon" aria-hidden="true">✎</span>{" "}
               input: <code>{summarizeSeed(seedSource)}</code>

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -48,6 +48,19 @@ function safeStringify(value: unknown, space?: number): string {
   }
 }
 
+function parseSeedVariables(source: string): Record<string, unknown> {
+  const parsed = JSON.parse(source);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error("Seed variables must be a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function summarizeSeed(source: string): string {
+  const oneLine = source.replace(/\s+/g, " ").trim();
+  return oneLine.length > 72 ? `${oneLine.slice(0, 72)}…` : oneLine;
+}
+
 interface LogEntry {
   id: number;
   kind: "start" | "task" | "done" | "vars" | "error";
@@ -55,6 +68,13 @@ interface LogEntry {
 }
 
 export function App() {
+  const [workerSources, setWorkerSources] = useState<string[]>(() =>
+    WORKER_DEFS.map((d) => d.source),
+  );
+  const [seedSource, setSeedSource] = useState(() =>
+    JSON.stringify(SEED_VARIABLES, null, 2),
+  );
+
   const {
     phase,
     error,
@@ -65,12 +85,11 @@ export function App() {
     reset,
   } = useBojtos({ bpmn: orderProcessBpmn });
 
-  const [sources, setSources] = useState<string[]>(() =>
-    WORKER_DEFS.map((d) => d.source),
-  );
   const [activeTab, setActiveTab] = useState(WORKER_DEFS[0].type);
   const [running, setRunning] = useState(false);
+  const [showInputEditor, setShowInputEditor] = useState(false);
   const [compileError, setCompileError] = useState<string | null>(null);
+  const [inputError, setInputError] = useState<string | null>(null);
   const [log, setLog] = useState<LogEntry[]>([]);
   const [displayVars, setDisplayVars] = useState<Record<string, unknown>>({});
 
@@ -87,7 +106,7 @@ export function App() {
   }, []);
 
   const setSource = useCallback((index: number, value: string) => {
-    setSources((prev) => {
+    setWorkerSources((prev) => {
       const next = [...prev];
       next[index] = value;
       return next;
@@ -97,12 +116,22 @@ export function App() {
   const run = useCallback(async () => {
     if (phase !== "ready" || runningRef.current) return;
 
+    let seedVariables: Record<string, unknown>;
+    try {
+      seedVariables = parseSeedVariables(seedSource);
+    } catch (e) {
+      setInputError(String(e));
+      return;
+    }
+    setInputError(null);
+    setCompileError(null);
+
     // Compile every editor first, so a syntax error is reported before we touch
     // the engine (and we can point at the offending worker).
     const workers: Record<string, JobHandler> = {};
     try {
       WORKER_DEFS.forEach((def, i) => {
-        const handler = compileHandler(sources[i]);
+        const handler = compileHandler(workerSources[i] ?? def.source);
         workers[def.type] = async (job) => {
           pushLog("task", `▶ ${def.label} — running ${def.type}`);
           const out = await handler(job);
@@ -120,18 +149,17 @@ export function App() {
       setCompileError(String(e));
       return;
     }
-    setCompileError(null);
 
     runningRef.current = true;
     setRunning(true);
     setLog([]);
-    setDisplayVars({ ...SEED_VARIABLES });
+    setDisplayVars({ ...seedVariables });
     try {
       // Fresh engine each run so completedInstances starts at 0.
       reset();
       const pid = processIds[0] ?? FALLBACK_PROCESS_ID;
       pushLog("start", `Order received — starting "${pid}"`);
-      let snap = createInstance(pid, JSON.stringify(SEED_VARIABLES));
+      let snap = createInstance(pid, JSON.stringify(seedVariables));
       await sleep(BEAT);
 
       let guard = 0;
@@ -151,7 +179,16 @@ export function App() {
       runningRef.current = false;
       setRunning(false);
     }
-  }, [phase, sources, processIds, createInstance, stepWorkers, reset, pushLog]);
+  }, [
+    phase,
+    seedSource,
+    workerSources,
+    processIds,
+    createInstance,
+    stepWorkers,
+    reset,
+    pushLog,
+  ]);
 
   const stop = useCallback(() => {
     runningRef.current = false;
@@ -214,10 +251,49 @@ export function App() {
               ↺ Reset
             </Button>
             {statusBadge}
-            <span className="seed">
-              seed: <code>{JSON.stringify(SEED_VARIABLES)}</code>
-            </span>
+            <button
+              type="button"
+              className="seed seed-button"
+              onClick={() => setShowInputEditor((v) => !v)}
+              disabled={running}
+              title="Click to edit input parameters"
+            >
+              <span className="seed-edit-icon" aria-hidden="true">✎</span>{" "}
+              input: <code>{summarizeSeed(seedSource)}</code>
+            </button>
           </div>
+          {showInputEditor && (
+            <div className="inline-input-editor">
+              <div className="editor-meta editor-meta-actions">
+                <div>
+                  <strong>Input parameters</strong>{" "}
+                  <code>JSON object</code>
+                </div>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowInputEditor(false)}
+                  size="sm"
+                >
+                  Done
+                </Button>
+              </div>
+              <div className="editor-wrap">
+                <Editor
+                  height="120px"
+                  defaultLanguage="json"
+                  value={seedSource}
+                  onChange={(v) => setSeedSource(v ?? "{}")}
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 13,
+                    scrollBeyondLastLine: false,
+                    tabSize: 2,
+                    automaticLayout: true,
+                  }}
+                />
+              </div>
+            </div>
+          )}
           {phase === "error" && (
             <Alert variant="destructive">
               <AlertTitle>Failed to load the engine</AlertTitle>
@@ -228,6 +304,12 @@ export function App() {
             <Alert variant="destructive">
               <AlertTitle>Worker code didn't compile</AlertTitle>
               <AlertDescription>{compileError}</AlertDescription>
+            </Alert>
+          )}
+          {inputError && (
+            <Alert variant="destructive">
+              <AlertTitle>Input variables are invalid</AlertTitle>
+              <AlertDescription>{inputError}</AlertDescription>
             </Alert>
           )}
         </section>
@@ -295,7 +377,7 @@ export function App() {
               <CardHeader>
                 <CardTitle>Service workers</CardTitle>
                 <CardDescription>
-                  Each handler serves one BPMN task type. Return the variables to
+                  Each handler serves one BPMN task type. Return variables to
                   merge, or throw to fail the job.
                 </CardDescription>
               </CardHeader>
@@ -317,9 +399,9 @@ export function App() {
                       </div>
                       <div className="editor-wrap">
                         <Editor
-                          height="320px"
+                          height="260px"
                           defaultLanguage="javascript"
-                          value={sources[i]}
+                          value={workerSources[i]}
                           onChange={(v) => setSource(i, v ?? "")}
                           options={{
                             minimap: { enabled: false },

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -115,16 +115,16 @@ export function App() {
 
   const run = useCallback(async () => {
     if (phase !== "ready" || runningRef.current) return;
+    setInputError(null);
+    setCompileError(null);
 
     let seedVariables: Record<string, unknown>;
     try {
       seedVariables = parseSeedVariables(seedSource);
     } catch (e) {
-      setInputError(String(e));
+      setInputError(e instanceof Error ? e.message : String(e));
       return;
     }
-    setInputError(null);
-    setCompileError(null);
 
     // Compile every editor first, so a syntax error is reported before we touch
     // the engine (and we can point at the offending worker).
@@ -146,7 +146,7 @@ export function App() {
         };
       });
     } catch (e) {
-      setCompileError(String(e));
+      setCompileError(e instanceof Error ? e.message : String(e));
       return;
     }
 

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -241,7 +241,9 @@ export function App() {
             <code>nodejs/</code> example — but there is no Camunda 8 cluster here.
             The real nanobpm engine executes the process in your browser. Edit a
             worker's JavaScript on the right, hit <strong>Run</strong>, and watch
-            the token move and the variables change.
+            the token move and the variables change. By default,{" "}
+            <code>check-inventory</code> marks orders with{" "}
+            <code>quantity &gt;= 10</code> as out of stock.
           </p>
           <div className="controls">
             <Button onClick={run} disabled={phase !== "ready" || running}>
@@ -256,7 +258,7 @@ export function App() {
               className="seed seed-button"
               onClick={() => setShowInputEditor((v) => !v)}
               disabled={running}
-              title="Click to edit input parameters"
+              title="Click to edit input parameters (quantity >= 10 becomes out of stock)"
             >
               <span className="seed-edit-icon" aria-hidden="true">✎</span>{" "}
               input: <code>{summarizeSeed(seedSource)}</code>

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -243,7 +243,9 @@ export function App() {
             worker's JavaScript on the right, hit <strong>Run</strong>, and watch
             the token move and the variables change. By default,{" "}
             <code>check-inventory</code> marks orders with{" "}
-            <code>quantity &gt;= 10</code> as out of stock.
+            <code>quantity &gt;= 10</code> as out of stock, and{" "}
+            <code>charge-payment</code>/<code>ship-items</code> raise an incident
+            when that happens.
           </p>
           <div className="controls">
             <Button onClick={run} disabled={phase !== "ready" || running}>
@@ -258,7 +260,7 @@ export function App() {
               className="seed seed-button"
               onClick={() => setShowInputEditor((v) => !v)}
               disabled={running}
-              title="Click to edit input parameters (quantity >= 10 becomes out of stock)"
+              title="Click to edit input parameters (quantity >= 10 becomes out of stock and raises incident)"
             >
               <span className="seed-edit-icon" aria-hidden="true">✎</span>{" "}
               input: <code>{summarizeSeed(seedSource)}</code>

--- a/2-order-process-with-service-workers/browser/src/App.tsx
+++ b/2-order-process-with-service-workers/browser/src/App.tsx
@@ -240,8 +240,8 @@ export function App() {
             This is the same BPMN and the same three service workers as the{" "}
             <code>nodejs/</code> example — but there is no Camunda 8 cluster here.
             The real nanobpm engine executes the process in your browser. Edit a
-            worker's JavaScript on the right, hit <strong>Run</strong>, and watch
-            the token move and the variables change.
+            worker's JavaScript and input values, hit <strong>Run</strong>, and
+            watch the token move and the variables change.
           </p>
           <div className="controls">
             <Button onClick={run} disabled={phase !== "ready" || running}>
@@ -256,7 +256,7 @@ export function App() {
               className="seed seed-button"
               onClick={() => setShowInputEditor((v) => !v)}
               disabled={running}
-              title="Click to edit input parameters"
+              title="Try changing input values and re-running"
             >
               <span className="seed-edit-icon" aria-hidden="true">✎</span>{" "}
               input: <code>{summarizeSeed(seedSource)}</code>

--- a/2-order-process-with-service-workers/browser/src/styles.css
+++ b/2-order-process-with-service-workers/browser/src/styles.css
@@ -77,6 +77,20 @@ body {
   font-size: 12px;
   opacity: 0.7;
 }
+.seed-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
+.seed-button:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+.seed-edit-icon {
+  opacity: 0.85;
+}
 .seed code,
 .intro code,
 .editor-meta code {
@@ -207,4 +221,9 @@ body {
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
   overflow: hidden;
+}
+
+.inline-input-editor {
+  max-width: 640px;
+  margin: 0 0 12px;
 }

--- a/2-order-process-with-service-workers/browser/src/workers.ts
+++ b/2-order-process-with-service-workers/browser/src/workers.ts
@@ -42,6 +42,10 @@ const CHECK_INVENTORY = `async (job) => {
 }`;
 
 const CHARGE_PAYMENT = `async (job) => {
+  if (job.variables.inStock === false) {
+    throw new Error("Item is out of stock; payment not charged.");
+  }
+
   const quantity = job.variables.quantity ?? 1;
   const unitPrice = 25; // try changing this and re-running
 
@@ -51,6 +55,10 @@ const CHARGE_PAYMENT = `async (job) => {
 }`;
 
 const SHIP_ITEMS = `async (job) => {
+  if (job.variables.inStock === false) {
+    throw new Error("Item is out of stock; nothing to ship.");
+  }
+
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   // Throw to fail the job and raise an incident on the diagram — try it!

--- a/2-order-process-with-service-workers/browser/src/workers.ts
+++ b/2-order-process-with-service-workers/browser/src/workers.ts
@@ -51,10 +51,40 @@ const SHIP_ITEMS = `async (job) => {
   return { shipped: true, tracking: "1Z" + Math.floor(Math.random() * 1e9) };
 }`;
 
+const GENERIC_HANDLER = (taskType: string, taskLabel: string) => `async (job) => {
+  // Variables from the process instance are available on 'job.variables'.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // Return an object to merge variables back into the instance.
+  return { "${taskType}Result": "${taskLabel} completed" };
+}`;
+
+const KNOWN_SOURCES: Record<string, string> = {
+  "check-inventory": CHECK_INVENTORY,
+  "charge-payment": CHARGE_PAYMENT,
+  "ship-items": SHIP_ITEMS,
+};
+
+export function defaultSourceForTask(type: string, label: string): string {
+  return KNOWN_SOURCES[type] ?? GENERIC_HANDLER(type, label);
+}
+
 export const WORKER_DEFS: WorkerDef[] = [
-  { type: "check-inventory", label: "Check inventory", source: CHECK_INVENTORY },
-  { type: "charge-payment", label: "Charge payment method", source: CHARGE_PAYMENT },
-  { type: "ship-items", label: "Ship items", source: SHIP_ITEMS },
+  {
+    type: "check-inventory",
+    label: "Check inventory",
+    source: defaultSourceForTask("check-inventory", "Check inventory"),
+  },
+  {
+    type: "charge-payment",
+    label: "Charge payment method",
+    source: defaultSourceForTask("charge-payment", "Charge payment method"),
+  },
+  {
+    type: "ship-items",
+    label: "Ship items",
+    source: defaultSourceForTask("ship-items", "Ship items"),
+  },
 ];
 
 /** The starting payload — identical to the Node.js example's seed. */

--- a/2-order-process-with-service-workers/browser/src/workers.ts
+++ b/2-order-process-with-service-workers/browser/src/workers.ts
@@ -27,9 +27,15 @@ export interface WorkerDef {
 const CHECK_INVENTORY = `async (job) => {
   // The starting variables flow in on 'job.variables'.
   const item = job.variables.item ?? "default-item";
+  const quantity = Number(job.variables.quantity ?? 1);
 
   // Pretend to check a warehouse (the Node.js worker waits 2000ms here).
   await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // For demo purposes: large orders are always out of stock.
+  if (quantity >= 10) {
+    return { item, inStock: false };
+  }
 
   // Whatever you return is merged onto the process instance's variables.
   return { item: item + " allocated", inStock: true };

--- a/2-order-process-with-service-workers/browser/src/workers.ts
+++ b/2-order-process-with-service-workers/browser/src/workers.ts
@@ -27,25 +27,15 @@ export interface WorkerDef {
 const CHECK_INVENTORY = `async (job) => {
   // The starting variables flow in on 'job.variables'.
   const item = job.variables.item ?? "default-item";
-  const quantity = Number(job.variables.quantity ?? 1);
 
   // Pretend to check a warehouse (the Node.js worker waits 2000ms here).
   await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // For demo purposes: large orders are always out of stock.
-  if (quantity >= 10) {
-    return { item, inStock: false };
-  }
 
   // Whatever you return is merged onto the process instance's variables.
   return { item: item + " allocated", inStock: true };
 }`;
 
 const CHARGE_PAYMENT = `async (job) => {
-  if (job.variables.inStock === false) {
-    throw new Error("Item is out of stock; payment not charged.");
-  }
-
   const quantity = job.variables.quantity ?? 1;
   const unitPrice = 25; // try changing this and re-running
 
@@ -55,10 +45,6 @@ const CHARGE_PAYMENT = `async (job) => {
 }`;
 
 const SHIP_ITEMS = `async (job) => {
-  if (job.variables.inStock === false) {
-    throw new Error("Item is out of stock; nothing to ship.");
-  }
-
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   // Throw to fail the job and raise an incident on the diagram — try it!

--- a/2-order-process-with-service-workers/browser/src/workers.ts
+++ b/2-order-process-with-service-workers/browser/src/workers.ts
@@ -52,11 +52,14 @@ const SHIP_ITEMS = `async (job) => {
 }`;
 
 const GENERIC_HANDLER = (taskType: string, taskLabel: string) => `async (job) => {
+  const resultKey = ${JSON.stringify(`${taskType}Result`)};
+  const resultValue = ${JSON.stringify(`${taskLabel} completed`)};
+
   // Variables from the process instance are available on 'job.variables'.
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   // Return an object to merge variables back into the instance.
-  return { "${taskType}Result": "${taskLabel} completed" };
+  return { [resultKey]: resultValue };
 }`;
 
 const KNOWN_SOURCES: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Add in-browser editing for **input parameters** and **service worker code** in `2-order-process-with-service-workers/browser`.
- Move input editing next to **Run/Reset** with a compact inline flow:
  - clickable input preview (`✎ input: ...`) in the control row,
  - inline JSON editor,
  - explicit **Done** button to close the editor.
- Keep worker editing in Monaco tabs (`check-inventory`, `charge-payment`, `ship-items`) and run with current edits.
- Update web app copy and `browser/README.md` to encourage experimentation by changing input values and worker code across repeated runs.

## Issue
Closes #63

## Notes
- BPMN model XML editing is intentionally **not** included in this PR.
- Default worker behavior stays simple/successful (no quantity-based out-of-stock rule).
